### PR TITLE
Fixed creation of new identity

### DIFF
--- a/simple-bot.go
+++ b/simple-bot.go
@@ -35,12 +35,40 @@ func cleanup() {
 	}
 }
 
+func askForLicenseKey() string {
+  fmt.Println("Please enter a licence key (format 1A2B3-C4E5F): ")
+  var response string
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(response) == 11  {
+		return response
+	} else {
+		return askForLicenseKey()
+	}
+}
+
+func askForDeviceUUID() string {
+  fmt.Println("Please enter a device-id (UUID format 12345678-1234-1234-1234-123456789012): ")
+  var response string
+	_, err := fmt.Scanln(&response)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(response) == 36  {
+		return response
+	} else {
+		return askForDeviceUUID()
+	}
+}
+
 func main(){
-
-
 	// Check if ID already exists
 	if  _,err := os.Stat(idpath); os.IsNotExist(err) {
-		threemaID,err = tr.CreateIdentity()
+        var uuid = askForDeviceUUID()
+        var lic = askForLicenseKey()
+		threemaID,err = tr.CreateIdentity(uuid, lic)
 		if (err != nil){
 			log.Fatalln(err)
 			os.Exit(1)


### PR DESCRIPTION
As the current version of the API is not supported the creation of a NEW identity is not possible anymore. The following error is the result: #2

Using the updated API and a license from the theema store (shop.threema.ch) it works again.

Adjustment of the dependencies might be needed as long as its not merged.

Also see: 
https://github.com/o3ma/o3rest/issues/2
https://github.com/o3ma/o3rest/pull/3
https://github.com/o3ma/o3/pull/29